### PR TITLE
feat: support script sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ import (
 func main() {
 	body, _ := json.Marshal(esquerydsl.QueryDoc{
 		Index: "some_index",
-		Sort:  []map[string]string{map[string]string{"id": "asc"}},
+		Sort:  []map[string]string{map[string]interface{}{"id": "asc"}},
 		And: []esquerydsl.QueryItem{
 			esquerydsl.QueryItem{
 				Field: "some_index_id",

--- a/esquerydsl.go
+++ b/esquerydsl.go
@@ -65,7 +65,7 @@ type QueryDoc struct {
 	Index       string
 	Size        int
 	From        int
-	Sort        []map[string]string
+	Sort        []map[string]interface{}
 	SearchAfter []interface{}
 	And         []QueryItem
 	Not         []QueryItem
@@ -167,11 +167,11 @@ func WrapQueryItems(itemType string, items ...QueryItem) QueryItem {
 //	    }
 //	}
 type queryReqDoc struct {
-	Query       queryWrap           `json:"query,omitempty"`
-	Size        int                 `json:"size,omitempty"`
-	From        int                 `json:"from,omitempty"`
-	Sort        []map[string]string `json:"sort,omitempty"`
-	SearchAfter []interface{}       `json:"search_after,omitempty"`
+	Query       queryWrap                `json:"query,omitempty"`
+	Size        int                      `json:"size,omitempty"`
+	From        int                      `json:"from,omitempty"`
+	Sort        []map[string]interface{} `json:"sort,omitempty"`
+	SearchAfter []interface{}            `json:"search_after,omitempty"`
 }
 
 type queryWrap struct {


### PR DESCRIPTION
Hi

I have a query where I need to use a [painless script sort](https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-sort-context.html) but the current type of `map[string]string` isn't compatible with using complex sorts.

The issue is the json marshal will escape the sort string before marshalling it. Moving to `map[string]interface` will avoid escaping and enable us to use more complex types. The example below will work as intended:

```go
	scriptSort := map[string]interface{}{
		"_script": map[string]interface{}{
			"type": "string",
			"script": map[string]interface{}{
				"source": "String name = doc['name'].value; return name.startsWith('name.prefix.') ? name.substring(12) : name;",
				"lang":   "painless",
			},
			"order": "asc",
		},
	}

```

